### PR TITLE
Skip switchport commands when working with vlan/loopback ip_interfaces.

### DIFF
--- a/templates/ipv4.j2
+++ b/templates/ipv4.j2
@@ -5,13 +5,13 @@
 
 {% if state == 'absent' %}
 interface {{ item.name }}
- {% if 'Loopback' not in item.name %}
+ {% if not item.name | re_search('[Ll]oopback|[Vv]lan') %}
    switchport
  {% endif %}
 
  {# If we find existing switchport config, then default settings #}
  {# These default commands only run the first time absent is called #}
- {% set switchport_block = base_config | config_block('interface ' ~ item.name, indent=3) %}
+ {% set switchport_block = _eos_config | config_block('interface ' ~ item.name, indent=3) %}
    {% if switchport_block %}
     {% if switchport_block | join('\n') | re_search('^ip address') %}
    default ip address
@@ -21,7 +21,7 @@ interface {{ item.name }}
 
 {% elif state == 'present' %}
 interface {{ item.name }}
- {% if 'Loopback' not in item.name %}
+ {% if not item.name | re_search('[Ll]oopback|[Vv]lan') %}
    no switchport
  {% endif %}
 


### PR DESCRIPTION
When working with vlan or loopback ip_interfaces, skip switchport commands.
Also fix default config name in template.

Fixes #4 
