### PR TITLE
Updates for handling Ansible 2.2 changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@
 eos_save_running_config: true
 
 default_ipv4_state: present
+
+resource_version: '2.2'

--- a/eos_module.yml
+++ b/eos_module.yml
@@ -21,6 +21,25 @@
         username: "{{ username | default(omit) }}"
       when: module == 'eos_command'
 
+    # Call the eos_config module if module is set to eos_config
+    - name: "{{ description | default('config playbook task') }}"
+      eos_config:
+        lines: "{{ lines | default(['']) }}"
+        parents: "{{ parents | default(omit) }}"
+        before: "{{ before | default(omit) }}"
+        after: "{{ after | default(omit) }}"
+        match: "{{ match | default('none')}}"
+        auth_pass: "{{ auth_pass | default(omit) }}"
+        authorize: "{{ authorize | default(omit) }}"
+        host: "{{ host | default(omit) }}"
+        password: "{{ password | default(omit) }}"
+        port: "{{ port | default(omit) }}"
+        provider: "{{ provider | default(omit) }}"
+        transport: "cli"
+        use_ssl: "{{ use_ssl | default(omit) }}"
+        username: "{{ username | default(omit) }}"
+      when: module == 'eos_config'
+
     # Call the eos_template module if module is set to eos_template
     - name: "{{ description | default('template playbook task') }}"
       eos_template:
@@ -35,4 +54,6 @@
         transport: "cli"
         use_ssl: "{{ use_ssl | default(omit) }}"
         username: "{{ username | default(omit) }}"
-      when: module == 'eos_template'
+      when: module == 'eos_template' and
+            (ansible_version.major < 2 or
+             (ansible_version.major == 2 and ansible_version.minor < 2))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+# Determine what resources we will use for running the role:
+# If using Ansible 2.1 or lower, we can use eos_template
+# If using Ansible 2.2 or higher, we must use eos_config
+# resource_version is set to 2.2 by default (since most users will be
+# on updated versions), change it if we're running 2.1 or lower.'
+- set_fact:
+    resource_version: '2.1'
+  when: ansible_version.major < 2 or
+        (ansible_version.major == 2 and ansible_version.minor < 2)
+
 - name: Gather EOS configuration
   eos_command:
     commands: 'show running-config all | exclude \.\*'
@@ -21,20 +31,6 @@
   no_log: "{{ no_log | default(true) }}"
   when: _eos_config is not defined
 
-- name: Arista EOS IPv4 resources
-  eos_template:
-    src: ipv4.j2
-    include_defaults: True
-    config: "{{ base_config | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    transport: "{{ transport | default(omit) }}"
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: ip_interfaces is defined
-  with_items: '{{ ip_interfaces }}'
+# Import the resource tasks based on the version of ansible in use
+- name: Include the Arista EOS IPv4 resources
+  include: "tasks/resources{{ resource_version }}.yml"

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -1,0 +1,20 @@
+# Perform the EOS IPv4 tasks under Ansible 2.1 or earlier
+# using the Ansible eos_template module
+
+- name: Arista EOS IPv4 resources (Ansible <= 2.1)
+  eos_template:
+    src: ipv4.j2
+    include_defaults: True
+    config: "{{ base_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: ip_interfaces is defined
+  with_items: '{{ ip_interfaces }}'

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -1,0 +1,20 @@
+# Perform the EOS IPv4 tasks under Ansible 2.2 or later
+# using the Ansible eos_config module
+
+- name: Arista EOS IPv4 resources (Ansible >= 2.1)
+  eos_config:
+    src: ipv4.j2
+    defaults: True
+    config: "{{ base_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: ip_interfaces is defined
+  with_items: '{{ ip_interfaces }}'

--- a/test/testcases/ipv4.yml
+++ b/test/testcases/ipv4.yml
@@ -179,10 +179,9 @@ testcases:
          mtu 1400
     absent: |
       interface Ethernet2
-         ip address 10.1.1.50/24
          mtu 7500
       interface Ethernet3
-         ip address 10.1.1.60/24
+         ip address 10.2.2.60/24
          mtu 7500
       interface Loopback0
          ip address 6.6.6.6/32
@@ -277,7 +276,7 @@ testcases:
          mtu 1400
     absent: |
       interface Ethernet3
-         ip address 10.1.1.60/24
+         ip address 10.2.2.60/24
          mtu 7500
       interface Loopback1
          ip address 7.7.7.7/32


### PR DESCRIPTION
Put tasks for eos_template and eos_config into separate resource
files, then import those task files into main according to the
version of Ansible being used.

Update test cases to fix errors in the expected result
